### PR TITLE
Add metric monitor thread

### DIFF
--- a/src/main/java/com/treasuredata/bigdam/log/Clock.java
+++ b/src/main/java/com/treasuredata/bigdam/log/Clock.java
@@ -1,0 +1,24 @@
+package com.treasuredata.bigdam.log;
+
+public class Clock
+{
+    public static long fixed = 0L;
+    public static boolean set = false;
+
+    public static synchronized long now()
+    {
+        return set ? fixed : System.nanoTime();
+    }
+
+    public static synchronized void set(final long v)
+    {
+        fixed = v;
+        set = true;
+    }
+
+    public static synchronized void clear()
+    {
+        set = false;
+        fixed = 0L;
+    }
+}

--- a/src/main/java/com/treasuredata/bigdam/log/ComplexMetric.java
+++ b/src/main/java/com/treasuredata/bigdam/log/ComplexMetric.java
@@ -1,0 +1,40 @@
+package com.treasuredata.bigdam.log;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+public class ComplexMetric
+{
+    private final String name;
+    private final Object value;
+    private final Map<String, Object> additional;
+
+    public ComplexMetric(final String name, final Object value, final String attrName, final Object attrValue)
+    {
+        this(name, value, ImmutableMap.of(attrName, attrValue));
+    }
+
+    public ComplexMetric(final String name, final Object value, final Map<String, Object> additional)
+    {
+        this.name = name;
+        this.value = value;
+        this.additional = additional;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public Object getValue()
+    {
+        return value;
+    }
+
+    public Map<String, Object> getAdditional()
+    {
+        return additional;
+    }
+}
+

--- a/src/main/java/com/treasuredata/bigdam/log/MetricMonitor.java
+++ b/src/main/java/com/treasuredata/bigdam/log/MetricMonitor.java
@@ -1,0 +1,170 @@
+package com.treasuredata.bigdam.log;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+public class MetricMonitor
+{
+    @FunctionalInterface
+    public interface MetricProducer
+    {
+        public Map<String, Object> produce();
+    }
+
+    @FunctionalInterface
+    public interface ComplexMetricProducer
+    {
+        public List<ComplexMetric> produce();
+    }
+
+    private final Log logger;
+
+    private final String tagPrefixMetric;
+    private final String tagPrefixRawMetric;
+    private final String metricFieldName;
+
+    private final List<MetricProducer> metricProducers;
+    private final List<MetricProducer> rawMetricProducers;
+    private final List<ComplexMetricProducer> metricProducersComplex;
+    private final List<ComplexMetricProducer> rawMetricProducersComplex;
+
+    private final int metricIntervalSeconds;
+
+    private final AtomicBoolean running;
+    private Thread monitorThread;
+    private long sleepIntervalMilliSeconds;
+
+    private static final long SLEEP_INTERVAL_MSEC = 800L;
+    private static final long MONITOR_THREAD_STOP_TIMEOUT = 2000L; // sleep interva * 2 + alpha
+
+    public MetricMonitor(
+            final Log logger,
+            final String tagPrefixMetric,
+            final String tagPrefixRawMetric,
+            final String metricFieldName,
+            final int metricIntervalSeconds
+    )
+    {
+        this.logger = logger;
+
+        this.tagPrefixMetric = tagPrefixMetric;
+        this.tagPrefixRawMetric = tagPrefixRawMetric;
+        this.metricFieldName = metricFieldName;
+
+        this.metricIntervalSeconds = metricIntervalSeconds;
+        this.sleepIntervalMilliSeconds = SLEEP_INTERVAL_MSEC;
+
+        this.metricProducers = new ArrayList<>();
+        this.rawMetricProducers = new ArrayList<>();
+        this.metricProducersComplex = new ArrayList<>();
+        this.rawMetricProducersComplex = new ArrayList<>();
+
+        this.running = new AtomicBoolean(false);
+    }
+
+    public void addMetricProducer(final MetricProducer producer)
+    {
+        metricProducers.add(producer);
+    }
+
+    public void addMetricProducer(final ComplexMetricProducer producer)
+    {
+        metricProducersComplex.add(producer);
+    }
+
+    public void addRawMetricProducer(final MetricProducer producer)
+    {
+        rawMetricProducers.add(producer);
+    }
+
+    public void addRawMetricProducer(final ComplexMetricProducer producer)
+    {
+        rawMetricProducersComplex.add(producer);
+    }
+
+    // only for MetricMonitorTest
+    void setSleepInterval(final long sleepInterval)
+    {
+        this.sleepIntervalMilliSeconds = sleepInterval;
+    }
+
+    public void start()
+    {
+        running.set(true);
+        monitorThread = new Thread(this::loop);
+        monitorThread.start();
+    }
+
+    public void stop()
+    {
+        running.set(false);
+        try {
+            monitorThread.join(MONITOR_THREAD_STOP_TIMEOUT);
+            if (monitorThread.isAlive()) {
+                monitorThread.interrupt();
+                monitorThread.join(MONITOR_THREAD_STOP_TIMEOUT);
+            }
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt(); // preserve interrupted status
+        }
+    }
+
+    private void loop()
+    {
+        long metricInterval = metricIntervalSeconds * 1_000_000_000L;
+
+        long nextTick = Clock.now() + metricInterval;
+        while (running.get()) {
+            try {
+                Thread.sleep(sleepIntervalMilliSeconds);
+                if (running.get() && Clock.now() >= nextTick) {
+                    nextTick += metricInterval; // to set nextTick even when run() throws exceptions
+                    run();
+                }
+            }
+            catch (Throwable e) {
+                logger.error(String.format("MetricMonitor got an error %s: %s", e.getClass().getName(), e.getMessage()), e);
+            }
+        }
+    }
+
+    private void run()
+    {
+        Instant now = Instant.now();
+
+        processMetric(logger, now, metricProducers, tagPrefixMetric);
+        processComplexMetric(logger, now, metricProducersComplex, tagPrefixMetric);
+
+        processMetric(logger, now, rawMetricProducers, tagPrefixRawMetric);
+        processComplexMetric(logger, now, rawMetricProducersComplex, tagPrefixRawMetric);
+    }
+
+    private void processMetric(Log logger, Instant now, List<MetricProducer> producers, String tagPrefix)
+    {
+        for (MetricProducer producer : producers) {
+            for (Map.Entry<String, Object> kv : producer.produce().entrySet()) {
+                logger.sendEvent(tagPrefix + kv.getKey(), now, ImmutableMap.of(metricFieldName, kv.getValue()));
+            }
+        }
+    }
+
+    private void processComplexMetric(Log logger, Instant now, List<ComplexMetricProducer> producers, String tagPrefix)
+    {
+        for (ComplexMetricProducer producer : producers) {
+            for (ComplexMetric metric : producer.produce()) {
+                Map<String, Object> record = ImmutableMap.<String, Object>builder()
+                        .put(metricFieldName, metric.getValue())
+                        .putAll(metric.getAdditional())
+                        .build();
+                logger.sendEvent(tagPrefix + metric.getName(), now, record);
+            }
+        }
+    }
+}

--- a/src/main/java/com/treasuredata/bigdam/log/MetricMonitor.java
+++ b/src/main/java/com/treasuredata/bigdam/log/MetricMonitor.java
@@ -41,7 +41,7 @@ public class MetricMonitor
     private long sleepIntervalMilliSeconds;
 
     private static final long SLEEP_INTERVAL_MSEC = 800L;
-    private static final long MONITOR_THREAD_STOP_TIMEOUT = 2000L; // sleep interva * 2 + alpha
+    private static final long MONITOR_THREAD_STOP_TIMEOUT = 2000L; // sleep interval * 2 + alpha
 
     public MetricMonitor(
             final Log logger,

--- a/src/main/java/com/treasuredata/bigdam/log/MetricMonitor.java
+++ b/src/main/java/com/treasuredata/bigdam/log/MetricMonitor.java
@@ -103,12 +103,17 @@ public class MetricMonitor
 
     public void stop()
     {
+        stop(MONITOR_THREAD_STOP_TIMEOUT);
+    }
+
+    public void stop(final long stopTimeoutMsec)
+    {
         running.set(false);
         try {
-            monitorThread.join(MONITOR_THREAD_STOP_TIMEOUT);
+            monitorThread.join(stopTimeoutMsec);
             if (monitorThread.isAlive()) {
                 monitorThread.interrupt();
-                monitorThread.join(MONITOR_THREAD_STOP_TIMEOUT);
+                monitorThread.join(stopTimeoutMsec);
             }
         }
         catch (InterruptedException e) {

--- a/src/test/java/com/treasuredata/bigdam/log/ClockTest.java
+++ b/src/test/java/com/treasuredata/bigdam/log/ClockTest.java
@@ -1,0 +1,36 @@
+package com.treasuredata.bigdam.log;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+public class ClockTest
+{
+    @After
+    public void teardown()
+    {
+        Clock.clear();
+    }
+
+    @Test
+    public void now()
+    {
+        long time1 = System.nanoTime();
+        long time2 = Clock.now();
+        long time3 = System.nanoTime();
+
+        assertThat(time2, is(greaterThanOrEqualTo(time1)));
+        assertThat(time2, is(lessThanOrEqualTo(time3)));
+
+        Clock.set(time2);
+        assertThat(Clock.now(), is(time2));
+
+        Clock.clear();
+        long time4 = System.nanoTime();
+        assertThat(time4, is(greaterThanOrEqualTo(time4)));
+    }
+}

--- a/src/test/java/com/treasuredata/bigdam/log/ComplexMetricTest.java
+++ b/src/test/java/com/treasuredata/bigdam/log/ComplexMetricTest.java
@@ -1,0 +1,37 @@
+package com.treasuredata.bigdam.log;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+public class ComplexMetricTest
+{
+    private ComplexMetric m;
+
+    @Test
+    public void createAndGetWithAnAttribute()
+    {
+        m = new ComplexMetric("metric1", 1, "name", "tagomoris");
+        assertThat(m.getName(), is("metric1"));
+        assertThat(m.getValue(), is(1));
+        assertThat(m.getAdditional().size(), is(1));
+        assertThat(m.getAdditional().get("name"), is("tagomoris"));
+    }
+
+    @Test
+    public void createAndGet()
+    {
+        m = new ComplexMetric("metric2", 100L, ImmutableMap.of("key1", 1, "key2", "value2", "tag", "TAG"));
+        assertThat(m.getName(), is("metric2"));
+        assertThat(m.getValue(), is(100L));
+        assertThat(m.getAdditional().size(), is(3));
+        assertThat(m.getAdditional().get("key1"), is(1));
+        assertThat(m.getAdditional().get("key2"), is("value2"));
+        assertThat(m.getAdditional().get("tag"), is("TAG"));
+    }
+}

--- a/src/test/java/com/treasuredata/bigdam/log/MetricMonitorTest.java
+++ b/src/test/java/com/treasuredata/bigdam/log/MetricMonitorTest.java
@@ -1,0 +1,154 @@
+package com.treasuredata.bigdam.log;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class MetricMonitorTest
+{
+    @After
+    public void teardown()
+    {
+        Clock.clear();
+    }
+
+    private void sleep(long milli)
+    {
+        try {
+            Thread.sleep(milli);
+        }
+        catch (InterruptedException e) {
+            throw new RuntimeException("test was interrupted", e);
+        }
+    }
+
+    @Test
+    public void createAndRunWithoutProducers()
+    {
+        Log logger = mock(Log.class);
+        MetricMonitor monitor = new MetricMonitor(logger, "metric.", "raw.", "v", 60);
+
+        long start = System.nanoTime();
+
+        Clock.set(start);
+        monitor.setSleepInterval(100L);
+
+        monitor.start();
+
+        sleep(500L);
+
+        verify(logger, never()).sendEvent(any(String.class), any(Instant.class), any());
+
+        long now = start + 60_100_000_000L; // 0.1sec for care of diff
+        Clock.set(now);
+
+        sleep(500L);
+
+        verify(logger, never()).sendEvent(any(String.class), any(Instant.class), any());
+
+        monitor.stop();
+    }
+
+    @Test
+    public void createAndRunWithMetrics()
+    {
+        Log logger = mock(Log.class);
+        MetricMonitor monitor = new MetricMonitor(logger, "metric.", "raw.", "v", 60);
+        monitor.addMetricProducer(() -> ImmutableMap.of("name1", 100, "name2", 1));
+        monitor.addMetricProducer(() -> ImmutableList.of(
+                new ComplexMetric("name3", 3, "label", "tagomoris"),
+                new ComplexMetric("name4", 400, ImmutableMap.of("k1", "v1", "k2", "v2"))
+        ));
+        monitor.addRawMetricProducer(() -> ImmutableMap.of("name5", 50, "name6", 6, "name7", 7000L));
+        monitor.addRawMetricProducer(() -> ImmutableList.of(new ComplexMetric("name8", 8, "k8", "v8")));
+
+        long start = System.nanoTime();
+
+        Clock.set(start);
+        monitor.setSleepInterval(100L);
+
+        monitor.start();
+
+        sleep(500L);
+
+        verify(logger, never()).sendEvent(any(String.class), any(Instant.class), any());
+
+        long now = start + 60_100_000_000L; // 0.1sec for care of diff
+        Clock.set(now);
+
+        sleep(500L);
+
+        verify(logger, times(1)).sendEvent(eq("metric.name1"), any(Instant.class), eq(ImmutableMap.of("v", 100)));
+        verify(logger, times(1)).sendEvent(eq("metric.name2"), any(Instant.class), eq(ImmutableMap.of("v", 1)));
+        verify(logger, times(1)).sendEvent(eq("metric.name3"), any(Instant.class), eq(ImmutableMap.of("v", 3, "label", "tagomoris")));
+        verify(logger, times(1)).sendEvent(eq("metric.name4"), any(Instant.class), eq(ImmutableMap.of("v", 400, "k1", "v1", "k2", "v2")));
+        verify(logger, times(1)).sendEvent(eq("raw.name5"), any(Instant.class), eq(ImmutableMap.of("v", 50)));
+        verify(logger, times(1)).sendEvent(eq("raw.name6"), any(Instant.class), eq(ImmutableMap.of("v", 6)));
+        verify(logger, times(1)).sendEvent(eq("raw.name7"), any(Instant.class), eq(ImmutableMap.of("v", 7000L)));
+        verify(logger, times(1)).sendEvent(eq("raw.name8"), any(Instant.class), eq(ImmutableMap.of("v", 8, "k8", "v8")));
+
+        monitor.stop();
+    }
+
+    private boolean exceptionThrown = false;
+
+    private Map<String, Object> buggyCode()
+    {
+        if (!exceptionThrown) {
+            exceptionThrown = true;
+            throw new RuntimeException("yaaay");
+        }
+        return ImmutableMap.of("name", 100);
+    }
+
+    @Test
+    public void handleExceptions()
+    {
+        Log logger = mock(Log.class);
+        MetricMonitor monitor = new MetricMonitor(logger, "metric.", "raw.", "v", 60);
+        monitor.addMetricProducer(this::buggyCode);
+
+        long start = System.nanoTime();
+
+        Clock.set(start);
+        monitor.setSleepInterval(100L);
+
+        monitor.start();
+
+        sleep(500L);
+
+        verify(logger, never()).sendEvent(any(String.class), any(Instant.class), any());
+
+        long now = start + 60_100_000_000L; // 0.1sec for care of diff
+        Clock.set(now);
+
+        sleep(500L);
+
+        verify(logger, times(1)).error(eq("MetricMonitor got an error java.lang.RuntimeException: yaaay"), any(RuntimeException.class));
+
+        now = now + 30_000_000_000L;
+        Clock.set(now);
+
+        sleep(500L);
+
+        verify(logger, never()).sendEvent(any(String.class), any(Instant.class), any());
+
+        now = now + 30_000_000_000L;
+        Clock.set(now);
+
+        sleep(500L);
+
+        verify(logger, times(1)).sendEvent(eq("metric.name"), any(Instant.class), eq(ImmutableMap.of("v", 100)));
+
+        monitor.stop();
+    }
+}


### PR DESCRIPTION
It's used as below in main:

```java
MetricMonitor monitor = new MetricMonitor(LOG, "metric.", "metric.raw.", "value", 60);
monitor.addMetricProducer(() -> {
  // return Map<String, Object> of metric-name-key and its value pairs
});
monitor.start();

// in shutdown hook
monitor.stop(); // it blocks until thread stops
```

This feature makes it enough easy to handle/push metric values from bigdam components.