### PR TITLE
fix to specify log levels as string

### DIFF
--- a/src/main/java/com/treasuredata/bigdam/log/Log.java
+++ b/src/main/java/com/treasuredata/bigdam/log/Log.java
@@ -71,28 +71,23 @@ public class Log
     private final Class<?> clazz;
     private Logger logger;
 
-    public enum LogLevel
-    {
-        TRACE, DEBUG, INFO, WARN, ERROR;
-    }
-
-    public static LogLevel getLevel(final String str)
+    public static Level getLevel(final String str)
     {
         String upcase = str.toUpperCase();
         if (upcase.equals("ERROR")) {
-            return LogLevel.ERROR;
+            return Level.ERROR;
         }
         if (upcase.equals("WARN")) {
-            return LogLevel.WARN;
+            return Level.WARN;
         }
         if (upcase.equals("INFO")) {
-            return LogLevel.INFO;
+            return Level.INFO;
         }
         if (upcase.equals("DEBUG")) {
-            return LogLevel.DEBUG;
+            return Level.DEBUG;
         }
         if (upcase.equals("TRACE")) {
-            return LogLevel.TRACE;
+            return Level.TRACE;
         }
         return null;
     }
@@ -246,27 +241,13 @@ public class Log
         fluency = fluencyGetterArg.apply(host, port);
     }
 
-    public static void setLogLevel(final LogLevel newLevel)
+    public static void setLogLevel(final String newLevel)
     {
-        switch (newLevel) {
-            case ERROR:
-                level = Level.ERROR;
-                break;
-            case WARN:
-                level = Level.WARN;
-                break;
-            case INFO:
-                level = Level.INFO;
-                break;
-            case DEBUG:
-                level = Level.DEBUG;
-                break;
-            case TRACE:
-                level = Level.TRACE;
-                break;
-            default:
-                throw new RuntimeException("BUG: Unknown LogLevel:" + newLevel);
+        Level newer = getLevel(newLevel);
+        if (newer == null) {
+            throw new IllegalArgumentException("BUG: Unknown LogLevel:" + newLevel);
         }
+        level = newer;
     }
 
     public static void setDefaultAttributes(final Map<String, ? extends Object> defaultAttributesArg)

--- a/src/test/java/com/treasuredata/bigdam/log/LogTest.java
+++ b/src/test/java/com/treasuredata/bigdam/log/LogTest.java
@@ -63,7 +63,7 @@ public class LogTest
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
         Log.setup(false, null, null, null, false, null, 0);
-        Log.setLogLevel(Log.LogLevel.WARN);
+        Log.setLogLevel("warn");
         Log log = new Log(LogTest.class);
         ch.qos.logback.classic.Logger underlying = (ch.qos.logback.classic.Logger) log.getUnderlying();
 
@@ -88,7 +88,7 @@ public class LogTest
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
         Log.setup(false, null, null, null, false, null, 0);
-        Log.setLogLevel(Log.LogLevel.WARN);
+        Log.setLogLevel("warn");
         Log log = new Log(LogTest.class);
         ch.qos.logback.classic.Logger underlying = (ch.qos.logback.classic.Logger) log.getUnderlying();
 
@@ -108,7 +108,7 @@ public class LogTest
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
         Log.setup(false, null, null, null, false, null, 0);
-        Log.setLogLevel(Log.LogLevel.DEBUG);
+        Log.setLogLevel("DEBUG");
         Log log = new Log(LogTest.class);
         ch.qos.logback.classic.Logger underlying = (ch.qos.logback.classic.Logger) log.getUnderlying();
 
@@ -128,7 +128,7 @@ public class LogTest
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
         Log.setup(false, null, null, null, false, null, 0);
-        Log.setLogLevel(Log.LogLevel.TRACE);
+        Log.setLogLevel("TRACE");
         Log log = new Log(LogTest.class);
         ch.qos.logback.classic.Logger underlying = (ch.qos.logback.classic.Logger) log.getUnderlying();
 


### PR DESCRIPTION
Same with sentryLevelThreshold.

I added a new enum for log levels, but existing code already use log levels (as log level threshold for Sentry) as String value.
And now, (after I wrote some lines of code to apply this feature to bigdam-pool), I think that it's better to specify log level as String on this library.