### PR TITLE
Add method to specify log level per package

### DIFF
--- a/src/main/java/com/treasuredata/bigdam/log/Log.java
+++ b/src/main/java/com/treasuredata/bigdam/log/Log.java
@@ -247,6 +247,18 @@ public class Log
         }
     }
 
+    public static void setLogLevel(final String packageName, final String newLevel)
+    {
+        Level newer = getLevel(newLevel);
+        if (newer == null) {
+            throw new IllegalArgumentException("BUG: Unknown LogLevel:" + newLevel);
+        }
+        Logger root = LoggerFactory.getLogger(packageName);
+        if (root instanceof ch.qos.logback.classic.Logger) {
+            ((ch.qos.logback.classic.Logger) root).setLevel(newer);
+        }
+    }
+
     public static void setDefaultAttributes(final Map<String, ? extends Object> defaultAttributesArg)
     {
         // all default attributes must be serializable as msgpack

--- a/src/test/java/com/treasuredata/bigdam/log/LogTest.java
+++ b/src/test/java/com/treasuredata/bigdam/log/LogTest.java
@@ -147,6 +147,27 @@ public class LogTest
         assertThat(loggingEvent.getFormattedMessage(), is("yay {k=v}"));
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    public void setLogLevelWithPackageName()
+            throws Exception
+    {
+        SentryClient sentry = mock(SentryClient.class);
+        Fluency fluency = mock(Fluency.class);
+        Log.setup(false, null, null, null, false, null, 0);
+        Log.setLogLevel("TRACE");
+        Log.setLogLevel("com.treasuredata.bigdam.log", "INFO");
+        Log log = new Log(LogTest.class);
+        ch.qos.logback.classic.Logger underlying = (ch.qos.logback.classic.Logger) log.getUnderlying();
+
+        Appender mockAppender = mock(Appender.class);
+        underlying.addAppender(mockAppender);
+
+        log.trace("yay", ImmutableMap.of("k", "v"));
+
+        verify(mockAppender, never()).doAppend(any());
+    }
+
     @Test
     public void initLoggerWithSentry()
             throws Exception


### PR DESCRIPTION
The motivation of this change is to suppress so much DEBUG/TRACE logs generated by `org.jboss.resteasy`, `org.xnio` and `io.undertow`. These logs sometimes help our debugging, but make it hard to find expected logs in many cases.
