### PR TITLE
Add sub-second time in record order by time correctly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'io.codearte.nexus-staging'
 
 group = "com.treasuredata.bigdam"
 archivesBaseName = "log"
-version = "0.8.0"
+version = "0.9.0"
 description = "Logging library for Bigdam components"
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
With logs after this patch, we can sort log records correctly using `ORDER BY time, stime` on TD tables.