### PR TITLE
PLT-10435: Add threshold for Fluentd events

### DIFF
--- a/src/main/java/com/treasuredata/bigdam/log/Log.java
+++ b/src/main/java/com/treasuredata/bigdam/log/Log.java
@@ -37,12 +37,12 @@ public class Log
     private static final String DEFAULT_DEBUG_TAG = "bigdam.log.debug";
     private static final String DEFAULT_TRACE_TAG = "bigdam.log.trace";
 
-    private static final int REMOTE_LEVEL_THRESHOLD_NEVER = 5;
-    private static final int REMOTE_LEVEL_THRESHOLD_ERROR = 4;
-    private static final int REMOTE_LEVEL_THRESHOLD_WARN = 3;
-    private static final int REMOTE_LEVEL_THRESHOLD_INFO = 2;
-    private static final int REMOTE_LEVEL_THRESHOLD_DEBUG = 1;
-    private static final int REMOTE_LEVEL_THRESHOLD_TRACE = 0;
+    private static final int LOG_SERVICE_LEVEL_THRESHOLD_NEVER = 5;
+    private static final int LOG_SERVICE_LEVEL_THRESHOLD_ERROR = 4;
+    private static final int LOG_SERVICE_LEVEL_THRESHOLD_WARN = 3;
+    private static final int LOG_SERVICE_LEVEL_THRESHOLD_INFO = 2;
+    private static final int LOG_SERVICE_LEVEL_THRESHOLD_DEBUG = 1;
+    private static final int LOG_SERVICE_LEVEL_THRESHOLD_TRACE = 0;
 
     private static final String SUBSECOND_TIME_FIELD = "stime";
 
@@ -54,10 +54,10 @@ public class Log
     private static int maskedValueLength = 8;
 
     private static SentryClient sentry = null;
-    private static int sentryLevel = REMOTE_LEVEL_THRESHOLD_NEVER;
+    private static int sentryLevel = LOG_SERVICE_LEVEL_THRESHOLD_NEVER;
 
     private static Fluency fluency = null;
-    private static int fluentdLevel = REMOTE_LEVEL_THRESHOLD_NEVER;
+    private static int fluentdLevel = LOG_SERVICE_LEVEL_THRESHOLD_NEVER;
 
     private static String errorTag = DEFAULT_ERROR_TAG;
     private static String warnTag = DEFAULT_WARN_TAG;
@@ -93,21 +93,21 @@ public class Log
 
     public static int getRemoteLevel(final String threshold)
     {
-        int level = REMOTE_LEVEL_THRESHOLD_NEVER;
+        int level = LOG_SERVICE_LEVEL_THRESHOLD_NEVER;
         if (threshold.equals("error")) {
-            level = REMOTE_LEVEL_THRESHOLD_ERROR;
+            level = LOG_SERVICE_LEVEL_THRESHOLD_ERROR;
         }
         else if (threshold.equals("warn")) {
-            level = REMOTE_LEVEL_THRESHOLD_WARN;
+            level = LOG_SERVICE_LEVEL_THRESHOLD_WARN;
         }
         else if (threshold.equals("info")) {
-            level = REMOTE_LEVEL_THRESHOLD_INFO;
+            level = LOG_SERVICE_LEVEL_THRESHOLD_INFO;
         }
         else if (threshold.equals("debug")) {
-            level = REMOTE_LEVEL_THRESHOLD_DEBUG;
+            level = LOG_SERVICE_LEVEL_THRESHOLD_DEBUG;
         }
         else if (threshold.equals("trace")) {
-            level = REMOTE_LEVEL_THRESHOLD_TRACE;
+            level = LOG_SERVICE_LEVEL_THRESHOLD_TRACE;
         }
         else {
             throw new IllegalArgumentException("Invalid log level for Fluentd/Sentry log level:" + threshold);
@@ -485,7 +485,7 @@ public class Log
     public void error(final String message)
     {
         logger.error(message);
-        if (isEnabled(fluentdLevel, REMOTE_LEVEL_THRESHOLD_ERROR)) {
+        if (isEnabled(fluentdLevel, LOG_SERVICE_LEVEL_THRESHOLD_ERROR)) {
             sendEvent(errorTag, message, null);
         }
     }
@@ -493,7 +493,7 @@ public class Log
     public void error(final String message, final Map<String, ? extends Object> attrs)
     {
         logger.error(message + " {}", filterAttrs(attrs));
-        if (isEnabled(fluentdLevel, REMOTE_LEVEL_THRESHOLD_ERROR)) {
+        if (isEnabled(fluentdLevel, LOG_SERVICE_LEVEL_THRESHOLD_ERROR)) {
             sendEvent(errorTag, message, attrs);
         }
     }
@@ -511,10 +511,10 @@ public class Log
         else {
             logger.error(message + " {}", filterAttrs(attrs), e);
         }
-        if (isEnabled(fluentdLevel, REMOTE_LEVEL_THRESHOLD_ERROR)) {
+        if (isEnabled(fluentdLevel, LOG_SERVICE_LEVEL_THRESHOLD_ERROR)) {
             sendEvent(errorTag, message, e, attrs);
         }
-        if (isEnabled(sentryLevel, REMOTE_LEVEL_THRESHOLD_ERROR)) {
+        if (isEnabled(sentryLevel, LOG_SERVICE_LEVEL_THRESHOLD_ERROR)) {
             sendException(e, attrs);
         }
     }
@@ -522,7 +522,7 @@ public class Log
     public void warn(final String message)
     {
         logger.warn(message);
-        if (isEnabled(fluentdLevel, REMOTE_LEVEL_THRESHOLD_WARN)) {
+        if (isEnabled(fluentdLevel, LOG_SERVICE_LEVEL_THRESHOLD_WARN)) {
             sendEvent(warnTag, message, null);
         }
     }
@@ -530,7 +530,7 @@ public class Log
     public void warn(final String message, final Map<String, ? extends Object> attrs)
     {
         logger.warn(message + " {}", filterAttrs(attrs));
-        if (isEnabled(fluentdLevel, REMOTE_LEVEL_THRESHOLD_WARN)) {
+        if (isEnabled(fluentdLevel, LOG_SERVICE_LEVEL_THRESHOLD_WARN)) {
             sendEvent(warnTag, message, attrs);
         }
     }
@@ -548,10 +548,10 @@ public class Log
         else {
             logger.warn(message + " {}", filterAttrs(attrs), e);
         }
-        if (isEnabled(fluentdLevel, REMOTE_LEVEL_THRESHOLD_WARN)) {
+        if (isEnabled(fluentdLevel, LOG_SERVICE_LEVEL_THRESHOLD_WARN)) {
             sendEvent(warnTag, message, e, attrs);
         }
-        if (isEnabled(sentryLevel, REMOTE_LEVEL_THRESHOLD_WARN)) {
+        if (isEnabled(sentryLevel, LOG_SERVICE_LEVEL_THRESHOLD_WARN)) {
             sendException(e, attrs);
         }
     }
@@ -559,7 +559,7 @@ public class Log
     public void info(final String message)
     {
         logger.info(message);
-        if (isEnabled(fluentdLevel, REMOTE_LEVEL_THRESHOLD_INFO)) {
+        if (isEnabled(fluentdLevel, LOG_SERVICE_LEVEL_THRESHOLD_INFO)) {
             sendEvent(infoTag, message, null);
         }
     }
@@ -567,7 +567,7 @@ public class Log
     public void info(final String message, final Map<String, ? extends Object> attrs)
     {
         logger.info(message + " {}", filterAttrs(attrs));
-        if (isEnabled(fluentdLevel, REMOTE_LEVEL_THRESHOLD_INFO)) {
+        if (isEnabled(fluentdLevel, LOG_SERVICE_LEVEL_THRESHOLD_INFO)) {
             sendEvent(infoTag, message, attrs);
         }
     }
@@ -585,10 +585,10 @@ public class Log
         else {
             logger.info(message + " {}", filterAttrs(attrs), e);
         }
-        if (isEnabled(fluentdLevel, REMOTE_LEVEL_THRESHOLD_INFO)) {
+        if (isEnabled(fluentdLevel, LOG_SERVICE_LEVEL_THRESHOLD_INFO)) {
             sendEvent(infoTag, message, e, attrs);
         }
-        if (isEnabled(sentryLevel, REMOTE_LEVEL_THRESHOLD_INFO)) {
+        if (isEnabled(sentryLevel, LOG_SERVICE_LEVEL_THRESHOLD_INFO)) {
             sendException(e, attrs);
         }
     }
@@ -596,7 +596,7 @@ public class Log
     public void debug(final String message)
     {
         logger.debug(message);
-        if (isEnabled(fluentdLevel, REMOTE_LEVEL_THRESHOLD_DEBUG)) {
+        if (isEnabled(fluentdLevel, LOG_SERVICE_LEVEL_THRESHOLD_DEBUG)) {
             sendEvent(debugTag, message, null);
         }
     }
@@ -604,7 +604,7 @@ public class Log
     public void debug(final String message, final Map<String, ? extends Object> attrs)
     {
         logger.debug(message + " {}", filterAttrs(attrs));
-        if (isEnabled(fluentdLevel, REMOTE_LEVEL_THRESHOLD_DEBUG)) {
+        if (isEnabled(fluentdLevel, LOG_SERVICE_LEVEL_THRESHOLD_DEBUG)) {
             sendEvent(debugTag, message, attrs);
         }
     }
@@ -622,10 +622,10 @@ public class Log
         else {
             logger.debug(message + " {}", filterAttrs(attrs), e);
         }
-        if (isEnabled(fluentdLevel, REMOTE_LEVEL_THRESHOLD_DEBUG)) {
+        if (isEnabled(fluentdLevel, LOG_SERVICE_LEVEL_THRESHOLD_DEBUG)) {
             sendEvent(debugTag, message, e, attrs);
         }
-        if (isEnabled(sentryLevel, REMOTE_LEVEL_THRESHOLD_DEBUG)) {
+        if (isEnabled(sentryLevel, LOG_SERVICE_LEVEL_THRESHOLD_DEBUG)) {
             sendException(e, attrs);
         }
     }
@@ -633,7 +633,7 @@ public class Log
     public void trace(final String message)
     {
         logger.trace(message);
-        if (isEnabled(fluentdLevel, REMOTE_LEVEL_THRESHOLD_TRACE)) {
+        if (isEnabled(fluentdLevel, LOG_SERVICE_LEVEL_THRESHOLD_TRACE)) {
             sendEvent(traceTag, message, null);
         }
     }
@@ -641,7 +641,7 @@ public class Log
     public void trace(final String message, final Map<String, ? extends Object> attrs)
     {
         logger.trace(message + " {}", filterAttrs(attrs));
-        if (isEnabled(fluentdLevel, REMOTE_LEVEL_THRESHOLD_TRACE)) {
+        if (isEnabled(fluentdLevel, LOG_SERVICE_LEVEL_THRESHOLD_TRACE)) {
             sendEvent(traceTag, message, attrs);
         }
     }
@@ -659,10 +659,10 @@ public class Log
         else {
             logger.trace(message + " {}", filterAttrs(attrs), e);
         }
-        if (isEnabled(fluentdLevel, REMOTE_LEVEL_THRESHOLD_TRACE)) {
+        if (isEnabled(fluentdLevel, LOG_SERVICE_LEVEL_THRESHOLD_TRACE)) {
             sendEvent(traceTag, message, e, attrs);
         }
-        if (isEnabled(sentryLevel, REMOTE_LEVEL_THRESHOLD_TRACE)) {
+        if (isEnabled(sentryLevel, LOG_SERVICE_LEVEL_THRESHOLD_TRACE)) {
             sendException(e, attrs);
         }
     }

--- a/src/test/java/com/treasuredata/bigdam/log/LogTest.java
+++ b/src/test/java/com/treasuredata/bigdam/log/LogTest.java
@@ -40,13 +40,73 @@ public class LogTest
     }
 
     @Test
+    public void getLevel()
+    {
+        assertThat(Log.getLevel("error"), is(Level.ERROR));
+        assertThat(Log.getLevel("warn"), is(Level.WARN));
+        assertThat(Log.getLevel("info"), is(Level.INFO));
+        assertThat(Log.getLevel("debug"), is(Level.DEBUG));
+        assertThat(Log.getLevel("trace"), is(Level.TRACE));
+    }
+
+    @Test
+    public void getRemoteLevel()
+    {
+        /*
+        private static final int REMOTE_LEVEL_THRESHOLD_NEVER = 5;
+        private static final int REMOTE_LEVEL_THRESHOLD_ERROR = 4;
+        private static final int REMOTE_LEVEL_THRESHOLD_WARN = 3;
+        private static final int REMOTE_LEVEL_THRESHOLD_INFO = 2;
+        private static final int REMOTE_LEVEL_THRESHOLD_DEBUG = 1;
+        private static final int REMOTE_LEVEL_THRESHOLD_TRACE = 0;
+        */
+        assertThat(Log.getRemoteLevel("error"), is(4));
+        assertThat(Log.getRemoteLevel("warn"), is(3));
+        assertThat(Log.getRemoteLevel("info"), is(2));
+        assertThat(Log.getRemoteLevel("debug"), is(1));
+        assertThat(Log.getRemoteLevel("trace"), is(0));
+    }
+
+    @Test
+    public void isEnabled()
+    {
+        int configured1 = Log.getRemoteLevel("info");
+        assertThat(Log.isEnabled(configured1, Log.getRemoteLevel("error")), is(true));
+        assertThat(Log.isEnabled(configured1, Log.getRemoteLevel("warn")), is(true));
+        assertThat(Log.isEnabled(configured1, Log.getRemoteLevel("info")), is(true));
+        assertThat(Log.isEnabled(configured1, Log.getRemoteLevel("debug")), is(false));
+        assertThat(Log.isEnabled(configured1, Log.getRemoteLevel("trace")), is(false));
+
+        int configured2 = Log.getRemoteLevel("trace");
+        assertThat(Log.isEnabled(configured2, Log.getRemoteLevel("error")), is(true));
+        assertThat(Log.isEnabled(configured2, Log.getRemoteLevel("warn")), is(true));
+        assertThat(Log.isEnabled(configured2, Log.getRemoteLevel("info")), is(true));
+        assertThat(Log.isEnabled(configured2, Log.getRemoteLevel("debug")), is(true));
+        assertThat(Log.isEnabled(configured2, Log.getRemoteLevel("trace")), is(true));
+
+        int configured3 = Log.getRemoteLevel("error");
+        assertThat(Log.isEnabled(configured3, Log.getRemoteLevel("error")), is(true));
+        assertThat(Log.isEnabled(configured3, Log.getRemoteLevel("warn")), is(false));
+        assertThat(Log.isEnabled(configured3, Log.getRemoteLevel("info")), is(false));
+        assertThat(Log.isEnabled(configured3, Log.getRemoteLevel("debug")), is(false));
+        assertThat(Log.isEnabled(configured3, Log.getRemoteLevel("trace")), is(false));
+
+        int configured4 = 5; // NEVER
+        assertThat(Log.isEnabled(configured4, Log.getRemoteLevel("error")), is(false));
+        assertThat(Log.isEnabled(configured4, Log.getRemoteLevel("warn")), is(false));
+        assertThat(Log.isEnabled(configured4, Log.getRemoteLevel("info")), is(false));
+        assertThat(Log.isEnabled(configured4, Log.getRemoteLevel("debug")), is(false));
+        assertThat(Log.isEnabled(configured4, Log.getRemoteLevel("trace")), is(false));
+    }
+
+    @Test
     public void initLoggerInDefault()
             throws Exception
     {
         Logger underlying = mock(Logger.class);
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
-        Log.setup(false, null, null, null, false, null, 0, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
+        Log.setup(false, null, null, null, false, null, null, 0, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
         Log log = new Log(LogTest.class);
 
         log.error("message");
@@ -64,7 +124,7 @@ public class LogTest
     {
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
-        Log.setup(false, null, null, null, false, null, 0);
+        Log.setup(false, null, null, null, false, null, null, 0);
         Log.setLogLevel("warn");
         Log log = new Log(LogTest.class);
         ch.qos.logback.classic.Logger underlying = (ch.qos.logback.classic.Logger) log.getUnderlying();
@@ -89,7 +149,7 @@ public class LogTest
     {
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
-        Log.setup(false, null, null, null, false, null, 0);
+        Log.setup(false, null, null, null, false, null, null, 0);
         Log.setLogLevel("warn");
         Log log = new Log(LogTest.class);
         ch.qos.logback.classic.Logger underlying = (ch.qos.logback.classic.Logger) log.getUnderlying();
@@ -109,7 +169,7 @@ public class LogTest
     {
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
-        Log.setup(false, null, null, null, false, null, 0);
+        Log.setup(false, null, null, null, false, null, null, 0);
         Log.setLogLevel("DEBUG");
         Log log = new Log(LogTest.class);
         ch.qos.logback.classic.Logger underlying = (ch.qos.logback.classic.Logger) log.getUnderlying();
@@ -129,7 +189,7 @@ public class LogTest
     {
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
-        Log.setup(false, null, null, null, false, null, 0);
+        Log.setup(false, null, null, null, false, null, null, 0);
         Log.setLogLevel("TRACE");
         Log log = new Log(LogTest.class);
         ch.qos.logback.classic.Logger underlying = (ch.qos.logback.classic.Logger) log.getUnderlying();
@@ -154,7 +214,7 @@ public class LogTest
     {
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
-        Log.setup(false, null, null, null, false, null, 0);
+        Log.setup(false, null, null, null, false, null, null, 0);
         Log.setLogLevel("TRACE");
         Log.setLogLevel("com.treasuredata.bigdam.log", "INFO");
         Log log = new Log(LogTest.class);
@@ -181,7 +241,7 @@ public class LogTest
         Logger underlying = mock(Logger.class);
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
-        Log.setup(true, "error", "https://public:private@host:443/1", Optional.empty(), true, "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
+        Log.setup(true, "error", "https://public:private@host:443/1", Optional.empty(), true, "trace", "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
         Log log = new Log(LogTest.class);
 
         String message = "yaaaaaaaaaaay";
@@ -209,6 +269,78 @@ public class LogTest
                         "nullKey", null)));
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    public void setSentryAndFluentdLogLevel()
+        throws Exception
+    {
+        Logger underlying = mock(Logger.class);
+        SentryClient sentry = mock(SentryClient.class);
+        Fluency fluency = mock(Fluency.class);
+        Log.setup(true, "warn", "https://public:private@host:443/1", Optional.empty(), true, "info", "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
+        Log log = new Log(LogTest.class);
+
+        String message = "yaaaaaaaaaaay";
+        Exception e = null;
+        try {
+            throw new RuntimeException(message);
+        }
+        catch (Exception ex) {
+            e = ex;
+            log.error("yay", ex, Attrs.of("key", "value", "nullKey", null));
+        }
+
+        assertThat(e, is(instanceOf(RuntimeException.class)));
+        assertThat(e.getMessage(), is(message));
+        verify(underlying).error(eq("yay {}"), eq(Attrs.of("key", "value", "nullKey", null)), eq(e));
+        verify(sentry, times(1)).sendEvent(any(EventBuilder.class));
+        verify(fluency, times(1)).emit(eq("bigdam.log.error"),
+                anyFluentdTimeStamp(),
+                eq(Attrs.of(
+                        "message", "yay",
+                        "stime", log.getLastTimestamp().getNano(),
+                        "errorClass", "java.lang.RuntimeException",
+                        "error", message,
+                        "key", "value",
+                        "nullKey", null)));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    public void setSentryAndFluentdLogLevelToBeIgnored()
+        throws Exception
+    {
+        Logger underlying = mock(Logger.class);
+        SentryClient sentry = mock(SentryClient.class);
+        Fluency fluency = mock(Fluency.class);
+        Log.setup(true, "error", "https://public:private@host:443/1", Optional.empty(), true, "error", "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
+        Log log = new Log(LogTest.class);
+
+        String message = "yaaaaaaaaaaay";
+        Exception e = null;
+        try {
+            throw new RuntimeException(message);
+        }
+        catch (Exception ex) {
+            e = ex;
+            log.warn("yay", ex, Attrs.of("key", "value", "nullKey", null));
+        }
+
+        assertThat(e, is(instanceOf(RuntimeException.class)));
+        assertThat(e.getMessage(), is(message));
+        verify(underlying).warn(eq("yay {}"), eq(Attrs.of("key", "value", "nullKey", null)), eq(e));
+        verify(sentry, never()).sendEvent(any(EventBuilder.class));
+        verify(fluency, never()).emit(eq("bigdam.log.warn"),
+                anyFluentdTimeStamp(),
+                eq(Attrs.of(
+                        "message", "yay",
+                        "stime", log.getLastTimestamp().getNano(),
+                        "errorClass", "java.lang.RuntimeException",
+                        "error", message,
+                        "key", "value",
+                        "nullKey", null)));
+    }
+
     private void throwExceptionForTest()
     {
         throw new RuntimeException(String.format("This is an exception thrown by unit tests: %d", System.nanoTime()));
@@ -222,7 +354,7 @@ public class LogTest
         assumeThat(dsn, is(notNullValue()));
         assumeThat(dsn, is(not("")));
         // if BIGDAM_LOG_TEST_SENTRY_DSN is not set, code below doesn't run
-        Log.setup(true, "error", dsn, Optional.empty(), false, null, 24224);
+        Log.setup(true, "error", dsn, Optional.empty(), false, null, null, 24224);
         Log log = new Log(LogTest.class);
         try {
             throwExceptionForTest();
@@ -243,7 +375,7 @@ public class LogTest
         Logger underlying = mock(Logger.class);
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
-        Log.setup(false, null, null, null, true, "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
+        Log.setup(false, null, null, null, true, "trace", "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
         Log log = new Log(LogTest.class);
 
         log.error("message 1");
@@ -277,7 +409,7 @@ public class LogTest
         Logger underlying = mock(Logger.class);
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
-        Log.setup(false, null, null, null, true, "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
+        Log.setup(false, null, null, null, true, "trace", "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
         Log log = new Log(LogTest.class);
 
         Map<String, Object> attrs = ImmutableMap.of("k", "vvvvvvvvvvvvvv", "k1", "v1", "k2", "v2");
@@ -301,7 +433,7 @@ public class LogTest
         Logger underlying = mock(Logger.class);
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
-        Log.setup(false, null, null, null, true, "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
+        Log.setup(false, null, null, null, true, "trace", "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
         Log.setDefaultAttributes(ImmutableMap.of("mykey", "myvalue", "myname", "tagomoris"));
         Log log = new Log(LogTest.class);
 
@@ -326,7 +458,7 @@ public class LogTest
         Logger underlying = mock(Logger.class);
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
-        Log.setup(false, null, null, null, true, "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
+        Log.setup(false, null, null, null, true, "trace", "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
         Map<String, Object> defaults = ImmutableMap.of("mykey", "myvalue", "myname", "tagomoris");
         Log.setDefaultAttributes(defaults);
         Log log = new Log(LogTest.class);
@@ -372,7 +504,7 @@ public class LogTest
         Logger underlying = mock(Logger.class);
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
-        Log.setup(false, null, null, null, true, "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
+        Log.setup(false, null, null, null, true, "trace", "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
         Map<String, Object> defaults = ImmutableMap.of("mykey", "myvalue", "myname", "tagomoris");
         Log.setDefaultAttributes(defaults);
         Log log = new Log(LogTest.class);
@@ -411,7 +543,7 @@ public class LogTest
         Logger underlying = mock(Logger.class);
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
-        Log.setup(false, null, null, null, true, "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
+        Log.setup(false, null, null, null, true, "trace", "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
         Log.setTagPrefix("bigdam.test.log.");
         Log log = new Log(LogTest.class);
 
@@ -429,7 +561,7 @@ public class LogTest
         Logger underlying = mock(Logger.class);
         SentryClient sentry = mock(SentryClient.class);
         Fluency fluency = mock(Fluency.class);
-        Log.setup(false, null, null, null, true, "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
+        Log.setup(false, null, null, null, true, "trace", "localhost", 24224, clazz -> underlying, (s) -> sentry, (s, i) -> fluency);
         Map<String, Object> defaults = ImmutableMap.of("mykey", "myvalue", "myname", "tagomoris");
         Log.setDefaultAttributes(defaults);
         Log.setAttributeKeysHidden(ImmutableList.of("k1", "k2"));


### PR DESCRIPTION
Naive all records (including all debug/trace events) are too much for massive traffic.
This change is to suppress such events via configuration.